### PR TITLE
Adição do campo UF na tabela cidades

### DIFF
--- a/database/migrations/2020_04_12_142619_add_uf_field_to_cidades.php
+++ b/database/migrations/2020_04_12_142619_add_uf_field_to_cidades.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUfFieldToCidades extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('cidades', function (Blueprint $table) {
+            $table->string('uf')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('cidades', function (Blueprint $table) {
+            $table->dropColumn('uf');
+        });
+    }
+}

--- a/resources/views/admin/cadastroAdmin.blade.php
+++ b/resources/views/admin/cadastroAdmin.blade.php
@@ -45,7 +45,7 @@
                                 <select class="browser-default custom-select" id="cidade_id" required name="cidade_id">
                                     <option value="" disable="" selected="" hidden="">-- Selecionar a Cidade --</option>
                                     @foreach($cidades as $cidade)
-                                        <option value="{{ $cidade->id }}" @if($cidade->id == old('cidade_id')) selected @endif>{{ $cidade->nome }}</option>
+                                        <option value="{{ $cidade->id }}" @if($cidade->id == old('cidade_id')) selected @endif> {{ $cidade->nome }} - {{ $cidade->uf }} </option>
                                     @endforeach
                                 </select>
                             </div>


### PR DESCRIPTION
Adição feita para que a listagem de cidades em cadastro de admins possa constar o estado ao lado. Estado esse que deve ser passado durante o cadastro de cidades.